### PR TITLE
New active features

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage
 
 On Mac/Linux/Windows just include into your rebar.config:
 
-    {active, ".*", {git, "git://github.com/synrc/active", {tag,"0.5"}}}
+    {active, ".*", {git, "git://github.com/Lol4t0/active", {branch,"master"}}}
 
 NOTE: on Linux please install inotify-tools.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage
 
 On Mac/Linux/Windows just include into your rebar.config:
 
-    {active, ".*", {git, "git://github.com/Lol4t0/active", {branch,"master"}}}
+    {active, ".*", {git, "git://github.com/synrc/active", {tag,"0.5"}}}
 
 NOTE: on Linux please install inotify-tools.
 

--- a/src/active_events.erl
+++ b/src/active_events.erl
@@ -1,0 +1,69 @@
+%%%-------------------------------------------------------------------
+%%% @author lol4t0
+%%% @copyright (C) 2015, <COMPANY>
+%%% @doc
+%%%
+%%% @end
+%%% Created : 03. Mar 2015 15:22
+%%%-------------------------------------------------------------------
+-module(active_events).
+-author("lol4t0").
+-behaviour(gen_event).
+
+%% API
+-export([start_link/0, subscribe_onload/1, subscribe_onnew/1, notify_reload/1, subscribe/2]).
+
+%% Callbacks
+-export([init/1, handle_event/2, handle_call/2, handle_info/2, terminate/2, code_change/3]).
+
+%% API impl
+start_link() ->
+    gen_event:start_link({local, ?MODULE}).
+
+-type mf() :: {M :: module(), F :: atom()}.
+-spec subscribe_onload(Function :: mf()) -> ok.
+subscribe_onload(Function) ->
+    subscribe(reloaded, Function).
+
+-spec subscribe_onnew(Function :: mf()) -> ok.
+subscribe_onnew(Function) ->
+    subscribe(loaded_new, Function).
+
+-spec subscribe(Event :: reloaded | loaded_new, Function :: mf()) -> ok.
+subscribe(Event, Function) ->
+    ok = gen_event:add_sup_handler(?MODULE, {?MODULE, Event}, [Event, Function]).
+
+notify_reload(Event) ->
+    gen_event:notify(?MODULE, Event).
+
+
+%% Callbacks impl
+-record(state, {
+    event :: reloaded | loaded_new,
+    function :: mf()
+}).
+
+init([Event, Function]) ->
+    {ok, #state{event = Event, function = Function}}.
+
+handle_event({Event, Module}, State = #state{event = Event, function = {Mod, Fun}}) ->
+    erlang:apply(Mod, Fun, [[Module]]),
+    {ok, State};
+handle_event(_, State) ->
+    {ok, State}.
+
+
+handle_call(_Request, _State) ->
+    erlang:error(not_implemented).
+
+handle_info(_Info, _State) ->
+    erlang:error(not_implemented).
+
+terminate(_Args, _State) ->
+   ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% Private dunctions
+

--- a/src/active_sup.erl
+++ b/src/active_sup.erl
@@ -5,5 +5,12 @@
 -define(CHILD(I, Type, Args), {I, {I, start_link, Args}, permanent, 5000, Type, [I]}).
 
 start_link() -> supervisor:start_link({local, ?MODULE}, ?MODULE, []).
-init([]) -> {ok, { {one_for_one, 5, 10}, [?CHILD(active, worker, [])]} }.
+init([]) -> 
+    {ok, { 
+        {one_for_one, 5, 10}, 
+        [
+            ?CHILD(active, worker, []), 
+            ?CHILD(active_events, worker, [])
+        ]
+    }}.
 


### PR DESCRIPTION
1. Apps whitelists. Let you sync only selected apps via `{apps, [lis, of, apps]}` in config file
2. Use `fs:path()` as root
3. Notifications on beam reload & new beam load.

 ```erlang
ok = active_events:subscribe_onload({Module, Function}), %% event hired when existing module is reloaded
ok = active_events:subscribe_onnew({Module, Function}). %% event hired when new module is loaded
```
 `Module:Function([RecompiledOrNewModule])` will be called on event.
 Using 2 events instead of one allows to differentiate logic, for example, you may want call `code_change` on module recompilation but this is useless for the new module.