### PR TITLE
Link references to related projects in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ACTIVE
 ======
 
-Active is sync replacement that uses native FileSystem OS async
+Active is a [sync][] replacement that uses native FileSystem OS async
 listeners to compile and reload Erlang files, DTL templates and
 other files. It acts as FS subscriber under supervision and
-uses MAD under the hood.
+uses [MAD][] under the hood.
 
 Listen Folders
 --------------
@@ -43,3 +43,6 @@ Credits
 * Vladimir Kirillov
 
 OM A HUM
+
+[sync]: https://github.com/rustyio/sync
+[MAD]: https://github.com/synrc/mad


### PR DESCRIPTION
Hi,

This is a trivial change, I made it partly to take the opportunity to share a few comments and ask project questions!

I am just beginning to get familiar with N2O, including the toolchain, and I'm fairly new to the Erlang ecosystem in general. Often I find that documentation in Synrc projects assumes some historical context which I lack as a newcomer, such as this at the beginning of [the MAD site](https://synrc.com/apps/mad/):

> Everything got started when Vladimir Kirillov decided to replace Rusty’s sync beam reloader.

I didn't know who Rusty is or what Sync is :smile:  It wasn't hard to find of course, but hopefully adding some links makes it even easier for other people like me in the future. Sync's documentation is rather good, while Active's currently isn't so great, so discovering what Sync is helped me to understand much more quickly what Active is for and how it is different.

I would definitely agree that using native filesystem event APIs is the way a tool like this should work in the modern day. Let's make Active's documentation better so more people can find and use it to take advantage of its improvements! I'll try to submit more explanations for the README soon as I use it more and read the code.

I am happy to contribute to documentation as I get to know N2O and related projects, hence this small change to start with. One question: I see where I could edit the MAD web site text I quoted above in the `doc` directory of the `mad` repo—how do I build the site from those TeX source files? Is the #n2o IRC channel the best place to ask these kinds of questions?

Thanks!