### PR TITLE
avoids active gen_server crash when a file is modified, in windows

### DIFF
--- a/src/active.erl
+++ b/src/active.erl
@@ -80,6 +80,7 @@ app(_,_)-> ok.
 
 top() -> lists:last(filename:split(fs:path())).
 
+compile(_App, []) -> ok;
 compile(App,Rest) ->
     case lists:last(Rest) of
          ".#" ++ _ -> skip;


### PR DESCRIPTION
In windows, when a file is modified (in apps folder only, e.g. index.erl), a chain of events are transmitted to active gen_server and somewhere before the modification of the beam file, active gen_server is crashed (and respawned with a different PID) and therefore doesn't accept any subsequent events and never reloads the modified *.beam file.
By adding this simple line we save the active gen_server crash.
This in conjunction with a minor change in fs project in inotifywait_win32.erl that corrects the name of MOVED_TO event flag fixes the windows sync code issue.