### PR TITLE
Remove deprecated `git://` protocol usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Usage
 
 On Mac/Linux/Windows just include into your rebar.config:
 
-    {active, ".*", {git, "git://github.com/synrc/active", {tag,"1.9"}}}
+    {active, ".*", {git, "https://github.com/synrc/active.git", {tag,"1.9"}}}
 
 NOTE: on Linux please install inotify-tools.
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,3 @@
 {erl_opts,[nowarn_deprecated_function]}.
-{deps, [{mad, ".*", {git, "git://github.com/synrc/mad", {tag,"master"}}},
-        {fs,  ".*", {git, "git://github.com/synrc/fs",  {tag,"master"}}}]}.
+{deps, [{mad, ".*", {git, "https://github.com/synrc/mad.git", {tag,"master"}}},
+        {fs,  ".*", {git, "https://github.com/synrc/fs.git",  {tag,"master"}}}]}.


### PR DESCRIPTION
At the moment it's impossible to install this dependency with [mad](https://github.com/synrc/mad) because GitHub deprecated `git://`
https://github.blog/2021-09-01-improving-git-protocol-security-github